### PR TITLE
chore(webpack): update config

### DIFF
--- a/packages/map-components/templates/webpack/package.json
+++ b/packages/map-components/templates/webpack/package.json
@@ -14,6 +14,7 @@
     "css-loader": "^6.7.2",
     "html-webpack-plugin": "^5.5.0",
     "style-loader": "^3.3.1",
+    "terser-webpack-plugin": "^5.3.9",    
     "webpack": "^5.84.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.11.1"

--- a/packages/map-components/templates/webpack/public/index.html
+++ b/packages/map-components/templates/webpack/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no"> 
+    <title>Map components webpack template</title>    
+  </head>
+  <body>
+    <arcgis-map item-id="d5dda743788a4b0688fe48f43ae7beb9">
+      <arcgis-search position="top-right"></arcgis-search>
+      <arcgis-legend position="bottom-left"></arcgis-search>
+    </arcgis-map>
+  </body>
+</html>

--- a/packages/map-components/templates/webpack/webpack.config.js
+++ b/packages/map-components/templates/webpack/webpack.config.js
@@ -12,68 +12,62 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const path = require('path');
 
-const HtmlWebPackPlugin = require("html-webpack-plugin");
-
-const path = require("path");
+const HtmlWebPackPlugin = require('html-webpack-plugin');
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = {
-  entry: ["./src/index.css", "./src/index.js"],
-
-  output: {
-    filename: "[id][name].js",
-    chunkFilename: "[id][name].js",
-    path: path.resolve(__dirname, "dist"),
-    clean: true,
+  entry: {
+    index: ['./src/index.css', './src/index.js']
   },
-
-  devtool: "source-map",
-
+  node: false,
+  optimization: {
+    minimizer: [
+      new TerserPlugin({extractComments: false}),
+    ],
+  },  
+  output: {
+    path: path.join(__dirname, 'dist'),
+    chunkFilename: 'chunks/[id].js',
+    publicPath: '',
+    clean: true
+  },
   devServer: {
     static: {
-      directory: path.join(__dirname, "dist"),
+      directory: path.join(__dirname, 'dist'),
     },
     compress: true,
-    port: 9000,
+    port: 3001,
   },
-
   module: {
     rules: [
       {
+        test: /\.js$/,
+        enforce: "pre",
+        use: ["source-map-loader"],
+      },
+      {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"], // Collect CSS and insert them into the page
+        use: [
+          MiniCssExtractPlugin.loader,
+          'css-loader'
+        ]
       },
-    ],
+    ]
   },
-
   plugins: [
-    // This plugin simplifies creation of HTML files to serve your webpack bundles.
     new HtmlWebPackPlugin({
-      title: "Map components webpack template",
-      chunksSortMode: "none",
-      meta: {
-        viewport:
-          "width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0, user-scalable=no",
-      },
-      templateContent: `
-        <!DOCTYPE html>
-          <html dir="ltr" lang="en">
-            <head>
-              <meta charset="utf-8">
-            </head>
-            <body>
-              <arcgis-map item-id="d5dda743788a4b0688fe48f43ae7beb9">
-                <arcgis-search position="top-right"></arcgis-search>
-                <arcgis-legend position="bottom-left"></arcgis-search>
-              </arcgis-map>
-            </body>
-          </html>`,
+      title: 'ArcGIS Maps SDK  for JavaScript',
+      template: './public/index.html',
+      filename: './index.html',
+      chunksSortMode: 'none',
+      inlineSource: '.(css)$'
     }),
-  ],
-
-  // Resolve property for importing files
-  resolve: {
-    modules: [path.resolve(__dirname, "/src"), "node_modules/"],
-    extensions: [".js", ".css"],
-  },
+    new MiniCssExtractPlugin({
+      filename: "[name].[chunkhash].css",
+      chunkFilename: "[id].css"
+    })
+  ]
 };

--- a/packages/map-components/templates/webpack/webpack.config.js
+++ b/packages/map-components/templates/webpack/webpack.config.js
@@ -12,15 +12,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const path = require('path');
+const path = require("path");
 
-const HtmlWebPackPlugin = require('html-webpack-plugin');
+const HtmlWebPackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const TerserPlugin = require("terser-webpack-plugin");
 
 module.exports = {
   entry: {
-    index: ['./src/index.css', './src/index.js']
+    index: ["./src/index.css", "./src/index.js"]
   },
   node: false,
   optimization: {
@@ -29,14 +29,14 @@ module.exports = {
     ],
   },  
   output: {
-    path: path.join(__dirname, 'dist'),
-    chunkFilename: 'chunks/[id].js',
-    publicPath: '',
+    path: path.join(__dirname, "dist"),
+    chunkFilename: "chunks/[id].js",
+    publicPath: "",
     clean: true
   },
   devServer: {
     static: {
-      directory: path.join(__dirname, 'dist'),
+      directory: path.join(__dirname, "dist"),
     },
     compress: true,
     port: 3001,
@@ -52,18 +52,18 @@ module.exports = {
         test: /\.css$/,
         use: [
           MiniCssExtractPlugin.loader,
-          'css-loader'
+          "css-loader"
         ]
       },
     ]
   },
   plugins: [
     new HtmlWebPackPlugin({
-      title: 'ArcGIS Maps SDK  for JavaScript',
-      template: './public/index.html',
-      filename: './index.html',
-      chunksSortMode: 'none',
-      inlineSource: '.(css)$'
+      title: "ArcGIS Maps SDK  for JavaScript",
+      template: "./public/index.html",
+      filename: "./index.html",
+      chunksSortMode: "none",
+      inlineSource: ".(css)$"
     }),
     new MiniCssExtractPlugin({
       filename: "[name].[chunkhash].css",


### PR DESCRIPTION
* Tweak the config
* Add terser to remove comments.
* Moved template to public/index.html

These mods reduce the number of on-disk files by almost half, from 1587 to 789. Application performance stayed pretty much the same in this PR.

_Final build and performance numbers_

```
-----------------------------
|> Application Performance <|
----------------------------- 
 --> bundle name: 29428.js 
 --> load time (ms): 7867 
 --> script runtime (ms): 15449 
 --> app load size: 14.54 MB 
 --> total JS requests: 93 
 --> total HTTP requests: 183 
 --> jsheap size: 37.62 MB 
-----------------------------


-----------------------------
|> Application Build Sizes <|
----------------------------- 
Build 
 --> file count: 789 
 --> size: 24.75 MB 
----------------------------- 
Main JS bundle 
 --> name: 29428.js 
 --> size: 1034.52 KB 
 --> gzip size: 281.88 KB 
 --> brotli size: 226.10 KB 
-----------------------------
```