### PR TITLE
chore: load core css in coding components samples

### DIFF
--- a/packages/coding-components/templates/amd-script-tag/index.html
+++ b/packages/coding-components/templates/amd-script-tag/index.html
@@ -25,8 +25,9 @@
     <link rel="icon" href="data:;base64,=" />
 
     <!-- Load Calcite Components. Note this could be after loading the ArcGIS Maps SDK for JS but before loading the Coding Components  -->
-    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/1.9.2/calcite.css" />
-    <script type="module" src="https://js.arcgis.com/calcite-components/1.9.2/calcite.esm.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/calcite-components/2.4.0/calcite.css" />
+    <link rel="stylesheet" type="text/css" href="https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/dark/main.css" />
+    <script type="module" src="https://js.arcgis.com/calcite-components/2.4.0/calcite.esm.js"></script>
 
     <!-- Load the ArcGIS Maps SDK for JavaScript -->
     <script src="https://js.arcgis.com/4.29/"></script>

--- a/packages/coding-components/templates/angular/src/index.html
+++ b/packages/coding-components/templates/angular/src/index.html
@@ -7,6 +7,7 @@
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/x-icon" href="favicon.ico" />
+  <link rel="stylesheet" href="https://js.arcgis.com/4.29/esri/themes/light/main.css" />
 </head>
 
 <body>

--- a/packages/coding-components/templates/angular/src/index.html
+++ b/packages/coding-components/templates/angular/src/index.html
@@ -7,7 +7,6 @@
   <base href="/" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="icon" type="image/x-icon" href="favicon.ico" />
-  <link rel="stylesheet" href="https://js.arcgis.com/4.29/esri/themes/light/main.css" />
 </head>
 
 <body>

--- a/packages/coding-components/templates/angular/src/styles.css
+++ b/packages/coding-components/templates/angular/src/styles.css
@@ -1,5 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
+@import "https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css";
 
 html,
 body {

--- a/packages/coding-components/templates/react/src/index.css
+++ b/packages/coding-components/templates/react/src/index.css
@@ -1,0 +1,1 @@
+@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';

--- a/packages/coding-components/templates/react/src/index.tsx
+++ b/packages/coding-components/templates/react/src/index.tsx
@@ -15,6 +15,8 @@
 
 import React from "react";
 import ReactDOM from "react-dom/client";
+import "./index.css";
+
 import ArcadeEditor from "./components/ArcadeEditor";
 import { defineCustomElements as defineCalciteElements } from "@esri/calcite-components/dist/loader";
 import { defineCustomElements as defineCodingElements } from "@arcgis/coding-components/dist/loader";

--- a/packages/coding-components/templates/vite/style.css
+++ b/packages/coding-components/templates/vite/style.css
@@ -1,5 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
+@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
 
 html,
 body {

--- a/packages/coding-components/templates/vite/style.css
+++ b/packages/coding-components/templates/vite/style.css
@@ -1,6 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
-@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
+@import "https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css";
 
 html,
 body {

--- a/packages/coding-components/templates/vue/src/assets/main.css
+++ b/packages/coding-components/templates/vue/src/assets/main.css
@@ -1,5 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
+@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
 
 html,
 body {

--- a/packages/coding-components/templates/vue/src/assets/main.css
+++ b/packages/coding-components/templates/vue/src/assets/main.css
@@ -1,6 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
-@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
+@import "https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css";
 
 html,
 body {

--- a/packages/coding-components/templates/webpack/src/index.css
+++ b/packages/coding-components/templates/webpack/src/index.css
@@ -1,5 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
+@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
 
 html,
 body {

--- a/packages/coding-components/templates/webpack/src/index.css
+++ b/packages/coding-components/templates/webpack/src/index.css
@@ -1,6 +1,6 @@
 @import "https://js.arcgis.com/coding-components/4.29/arcgis-coding-components.css";
 @import "https://js.arcgis.com/calcite-components/2.4.0/calcite.css";
-@import 'https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
+@import "https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css";
 
 html,
 body {


### PR DESCRIPTION
This PR updates the coding components samples to load the @arcgis/core styles. There were concerns that in the case that a user loaded a private webmap, they would see an unstyled dialog popup. This fixes that.