### PR TITLE
chore: updated charts tutorial solution

### DIFF
--- a/packages/charts-components/tutorials/charts-components-with-map-components-solution/index.html
+++ b/packages/charts-components/tutorials/charts-components-with-map-components-solution/index.html
@@ -8,8 +8,8 @@
 </head>
 
 <body>
-  <arcgis-map item-id="a72bb6468f57491f84409186446808e1" id="map"></arcgis-map>
-  <arcgis-charts-scatter-plot id="scatter-plot"></arcgis-charts-scatter-plot>
+  <arcgis-map item-id="a72bb6468f57491f84409186446808e1"></arcgis-map>
+  <arcgis-charts-scatter-plot id="scatterplot"></arcgis-charts-scatter-plot>
   <script type="module" src="main.js"></script>
 </body>
 

--- a/packages/charts-components/tutorials/charts-components-with-map-components-solution/main.js
+++ b/packages/charts-components/tutorials/charts-components-with-map-components-solution/main.js
@@ -49,19 +49,19 @@ document.querySelector("arcgis-map").addEventListener("arcgisViewReadyChange", (
   /**
    * Get the layer from the mapElement and the config from the layer
    */
-  const layer = map.layers.items[0];
-  const config = layer.charts[0];
+  const featureLayer = map.layers.find((layer) => layer.title === "CollegeScorecard_Charts");
+  const scatterplotConfig = featureLayer.charts[0];
 
   /**
    * Get a reference to the `arcgis-charts-scatter-plot` element
    */
-  const scatterPlotElement = document.getElementById("scatter-plot");
+  const scatterplotElement = document.querySelector("arcgis-charts-scatter-plot");
 
   /**
    * Assign the config and the layer to the chart element to render the chart
    */
-  scatterPlotElement.layer = layer;
-  scatterPlotElement.config = config;
+  scatterplotElement.config = scatterplotConfig;
+  scatterplotElement.layer = featureLayer;
 
   /**
    * Get the layerView from the view
@@ -69,7 +69,7 @@ document.querySelector("arcgis-map").addEventListener("arcgisViewReadyChange", (
    */
   const featureLayerViews = view.layerViews;
 
-  scatterPlotElement.addEventListener("arcgisChartsSelectionComplete", (event) => {
+  scatterplotElement.addEventListener("arcgisChartsSelectionComplete", (event) => {
     map.highlightSelect?.remove();
     map.highlightSelect = featureLayerViews.items[0].highlight(event.detail.selectionOIDs);
   });

--- a/packages/charts-components/tutorials/charts-components-with-map-components-solution/style.css
+++ b/packages/charts-components/tutorials/charts-components-with-map-components-solution/style.css
@@ -1,4 +1,5 @@
-@import 'https://jsdev.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css';
+/* import the `@arcgis/core` light theme */
+@import "https://js.arcgis.com/4.29/@arcgis/core/assets/esri/themes/light/main.css";
 
 html,
 body {
@@ -8,7 +9,7 @@ body {
   width: 100%;
 }
 
-#scatter-plot {
+#scatterplot {
   position: absolute;
   bottom: 100px;
   left: 30px;


### PR DESCRIPTION
- Updated chart's tutorials solution folder to match the upcoming changes to the tutorial MDX on developer site
- Addressed some feedback about using `map.layers.item[0]`, now using `layers.find()`
- Renamed `Scatter plot` to `Scatterplot`
- Removed instance of `jsdev`