### PR TITLE
chore: updated calcite asset versioning for charts components templates

### DIFF
--- a/packages/charts-components/templates/vue/src/main.js
+++ b/packages/charts-components/templates/vue/src/main.js
@@ -13,16 +13,16 @@
  * limitations under the License.
  */
 
-import './assets/main.css';
+import "./assets/main.css";
 
-import { createApp } from 'vue';
-import App from './App.vue';
+import { createApp } from "vue";
+import App from "./App.vue";
 
-import { defineCustomElements as defineCalciteElements } from '@esri/calcite-components/dist/loader';
-import { defineCustomElements as defineChartsElements } from '@arcgis/charts-components/dist/loader';
+import { defineCustomElements as defineCalciteElements } from "@esri/calcite-components/dist/loader";
+import { defineCustomElements as defineChartsElements } from "@arcgis/charts-components/dist/loader";
 
 // define custom elements in the browser, and load the assets from the CDN
-defineCalciteElements(window, { resourcesUrl: 'https://js.arcgis.com/calcite-components/4.29/assets' });
-defineChartsElements(window, { resourcesUrl: 'https://js.arcgis.com/charts-components/4.29/t9n' });
+defineCalciteElements(window, { resourcesUrl: "https://js.arcgis.com/calcite-components/2.5.1/assets" });
+defineChartsElements(window, { resourcesUrl: "https://js.arcgis.com/charts-components/4.29/t9n" });
 
-createApp(App).mount('#app');
+createApp(App).mount("#app");

--- a/packages/charts-components/templates/webpack/src/index.js
+++ b/packages/charts-components/templates/webpack/src/index.js
@@ -13,25 +13,25 @@
  * limitations under the License.
  */
 
-import { ScatterPlotModel } from '@arcgis/charts-model';
-import { loadFeatureLayer } from './load-data';
+import { ScatterPlotModel } from "@arcgis/charts-model";
+import { loadFeatureLayer } from "./load-data";
 
-import { defineCustomElements as defineCalciteElements } from '@esri/calcite-components/dist/loader';
-import { defineCustomElements as defineChartsElements } from '@arcgis/charts-components/dist/loader';
+import { defineCustomElements as defineCalciteElements } from "@esri/calcite-components/dist/loader";
+import { defineCustomElements as defineChartsElements } from "@arcgis/charts-components/dist/loader";
 
 // define custom elements in the browser, and load the assets from the CDN
-defineCalciteElements(window, { resourcesUrl: 'https://js.arcgis.com/calcite-components/4.29/assets' });
-defineChartsElements(window, { resourcesUrl: 'https://js.arcgis.com/charts-components/4.29/t9n' });
+defineCalciteElements(window, { resourcesUrl: "https://js.arcgis.com/calcite-components/4.29/assets" });
+defineChartsElements(window, { resourcesUrl: "https://js.arcgis.com/charts-components/4.29/t9n" });
 
 (async () => {
-  const scatterPlotRef = document.querySelector('arcgis-charts-scatter-plot');
+  const scatterPlotRef = document.querySelector("arcgis-charts-scatter-plot");
 
-  const featureLayer = await loadFeatureLayer('8871626e970a4f3e9d6113ec63a92f2f');
+  const featureLayer = await loadFeatureLayer("8871626e970a4f3e9d6113ec63a92f2f");
 
   const scatterPlotParams = {
     layer: featureLayer,
-    xAxisFieldName: 'Earnings',
-    yAxisFieldName: 'Cost',
+    xAxisFieldName: "Earnings",
+    yAxisFieldName: "Cost"
   };
 
   const scatterPlotModel = new ScatterPlotModel(scatterPlotParams);

--- a/packages/charts-components/templates/webpack/src/index.js
+++ b/packages/charts-components/templates/webpack/src/index.js
@@ -20,7 +20,7 @@ import { defineCustomElements as defineCalciteElements } from "@esri/calcite-com
 import { defineCustomElements as defineChartsElements } from "@arcgis/charts-components/dist/loader";
 
 // define custom elements in the browser, and load the assets from the CDN
-defineCalciteElements(window, { resourcesUrl: "https://js.arcgis.com/calcite-components/4.29/assets" });
+defineCalciteElements(window, { resourcesUrl: "https://js.arcgis.com/calcite-components/2.5.1/assets" });
 defineChartsElements(window, { resourcesUrl: "https://js.arcgis.com/charts-components/4.29/t9n" });
 
 (async () => {


### PR DESCRIPTION
Updated calcite assets version from `4.29` to `2.5.1` for main branch. Tested locally, chart was able to load.