### PR TITLE
chore: prepare to archive repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> ⚠️ ArcGIS Maps SDK for JavaScript components are no longer in beta. This repository has been archived. Please visit https://github.com/Esri/jsapi-resources for the latest samples.
+
 # ArcGIS Maps SDK for JavaScript samples
 
 This repository contains code samples and templates for coding with the ArcGIS Maps SDK for JavaScript.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 > ⚠️ ArcGIS Maps SDK for JavaScript components are no longer in beta. This repository has been archived. Please visit https://github.com/Esri/jsapi-resources for the latest samples.
 
-# ArcGIS Maps SDK for JavaScript samples
+# ArcGIS Maps SDK for JavaScript samples (Archived)
 
 This repository contains code samples and templates for coding with the ArcGIS Maps SDK for JavaScript.
 

--- a/packages/coding-components/README.MD
+++ b/packages/coding-components/README.MD
@@ -1,5 +1,5 @@
-# Coding components (beta)
+> ⚠️ ArcGIS Maps SDK for JavaScript components are no longer in beta. This repository has been archived. Please visit https://github.com/Esri/jsapi-resources for the latest samples.
 
-> **Disclaimer:** Components are in beta. Please do not contact Esri Technical Support for assistance.
+# Coding components
 
 These templates and samples are for [@arcgis/coding-components](https://www.npmjs.com/package/@arcgis/coding-components)

--- a/packages/map-components/README.MD
+++ b/packages/map-components/README.MD
@@ -1,6 +1,6 @@
-# Map components (beta)
+> ⚠️ ArcGIS Maps SDK for JavaScript components are no longer in beta. This repository has been archived. Please visit https://github.com/Esri/jsapi-resources for the latest samples.
 
-> **Disclaimer:** Components are in beta. Please do not contact Esri Technical Support for assistance.
+# Map components
 
 These templates and samples are for [@arcgis/map-components](https://www.npmjs.com/package/@arcgis/map-components)
 


### PR DESCRIPTION
Map and coding components are out beta, and no more patches are planned for 4.30. 

Visitors should check out https://github.com/Esri/jsapi-resources for the latest samples.